### PR TITLE
Add missing command shortcuts: yarn:, bun:, node:, deno: (#12)

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -57,9 +57,25 @@ fn npm_expander(cmd: &str) -> String {
 fn pnpm_expander(cmd: &str) -> String {
   cmd.replace("pnpm:", "pnpm run ")
 }
+fn yarn_expander(cmd: &str) -> String {
+  cmd.replace("yarn:", "yarn run ")
+}
+fn bun_expander(cmd: &str) -> String {
+  cmd.replace("bun:", "bun run ")
+}
+fn node_expander(cmd: &str) -> String {
+  cmd.replace("node:", "node --run ")
+}
+fn deno_expander(cmd: &str) -> String {
+  cmd.replace("deno:", "deno task ")
+}
 
 pub fn expand(cmd: &str) -> String {
   let cmd = pnpm_expander(cmd);
+  let cmd = yarn_expander(&cmd);
+  let cmd = bun_expander(&cmd);
+  let cmd = node_expander(&cmd);
+  let cmd = deno_expander(&cmd);
   npm_expander(&cmd)
 }
 
@@ -117,24 +133,17 @@ fn get_name(
 
   // if not, check for a npm command.
 
-  let is_pnpm_cmd: bool = raw_cmd.contains("pnpm:");
-  let is_npm_cmd: bool = raw_cmd.starts_with("npm:");
-  let is_yarn_cmd: bool = raw_cmd.contains("yarn:");
+  let prefixes = ["pnpm:", "yarn:", "bun:", "node:", "deno:", "npm:"];
   let default_name = format!("{}", index);
 
-  let backup_name: &str;
+  let backup_name: String = prefixes
+    .iter()
+    .find(|p| raw_cmd.contains(**p))
+    .and_then(|p| raw_cmd.split(p).nth(1))
+    .unwrap_or(&default_name)
+    .to_string();
 
-  if is_pnpm_cmd {
-    backup_name = raw_cmd.split("pnpm:").collect::<Vec<&str>>()[1]
-  } else if is_yarn_cmd {
-    backup_name = raw_cmd.split("yarn:").collect::<Vec<&str>>()[1]
-  } else if is_npm_cmd {
-    backup_name = raw_cmd.split("npm:").collect::<Vec<&str>>()[1]
-  } else {
-    backup_name = &default_name;
-  }
-
-  backup_name.to_string()
+  backup_name
 }
 
 fn truncate(s: &str, max_chars: usize) -> &str {

--- a/src/command.rs
+++ b/src/command.rs
@@ -52,24 +52,45 @@ impl Process {
 }
 
 fn npm_expander(cmd: &str) -> String {
-  cmd.replace("npm:", "npm run ")
+  match cmd.strip_prefix("npm:") {
+    Some(rest) => format!("npm run {rest}"),
+    None => cmd.to_string(),
+  }
 }
 fn pnpm_expander(cmd: &str) -> String {
-  cmd.replace("pnpm:", "pnpm run ")
+  match cmd.strip_prefix("pnpm:") {
+    Some(rest) => format!("pnpm run {rest}"),
+    None => cmd.to_string(),
+  }
 }
 fn yarn_expander(cmd: &str) -> String {
-  cmd.replace("yarn:", "yarn run ")
+  match cmd.strip_prefix("yarn:") {
+    Some(rest) => format!("yarn run {rest}"),
+    None => cmd.to_string(),
+  }
 }
 fn bun_expander(cmd: &str) -> String {
-  cmd.replace("bun:", "bun run ")
+  match cmd.strip_prefix("bun:") {
+    Some(rest) => format!("bun run {rest}"),
+    None => cmd.to_string(),
+  }
 }
 fn node_expander(cmd: &str) -> String {
-  cmd.replace("node:", "node --run ")
+  match cmd.strip_prefix("node:") {
+    Some(rest) => format!("node --run {rest}"),
+    None => cmd.to_string(),
+  }
 }
 fn deno_expander(cmd: &str) -> String {
-  cmd.replace("deno:", "deno task ")
+  match cmd.strip_prefix("deno:") {
+    Some(rest) => format!("deno task {rest}"),
+    None => cmd.to_string(),
+  }
 }
 
+// Expansion order: with strip_prefix, each expander only matches at the start
+// of the string, so order no longer affects correctness (e.g., "pnpm:" won't
+// false-match "npm:"). Only one expander can ever match a given command.
 pub fn expand(cmd: &str) -> String {
   let cmd = pnpm_expander(cmd);
   let cmd = yarn_expander(&cmd);
@@ -131,24 +152,136 @@ fn get_name(
     return name;
   }
 
-  // if not, check for a npm command.
+  // if not, extract the task name from a package-manager prefix (e.g. "yarn:test" → "test").
+  // Uses strip_prefix so only start-of-string prefixes match, consistent with expand().
 
   let prefixes = ["pnpm:", "yarn:", "bun:", "node:", "deno:", "npm:"];
   let default_name = format!("{}", index);
 
-  let backup_name: String = prefixes
+  prefixes
     .iter()
-    .find(|p| raw_cmd.contains(**p))
-    .and_then(|p| raw_cmd.split(p).nth(1))
+    .find_map(|p| raw_cmd.strip_prefix(p))
     .unwrap_or(&default_name)
-    .to_string();
-
-  backup_name
+    .to_string()
 }
 
 fn truncate(s: &str, max_chars: usize) -> &str {
   match s.char_indices().nth(max_chars) {
     None => s,
     Some((idx, _)) => &s[..idx],
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // ── expand() ──────────────────────────────────────────────
+
+  #[test]
+  fn expand_npm() {
+    assert_eq!(expand("npm:test"), "npm run test");
+  }
+
+  #[test]
+  fn expand_pnpm() {
+    assert_eq!(expand("pnpm:build"), "pnpm run build");
+  }
+
+  #[test]
+  fn expand_yarn() {
+    assert_eq!(expand("yarn:test"), "yarn run test");
+  }
+
+  #[test]
+  fn expand_bun() {
+    assert_eq!(expand("bun:dev"), "bun run dev");
+  }
+
+  #[test]
+  fn expand_node() {
+    assert_eq!(expand("node:test"), "node --run test");
+  }
+
+  #[test]
+  fn expand_deno() {
+    assert_eq!(expand("deno:serve"), "deno task serve");
+  }
+
+  #[test]
+  fn expand_no_prefix_passthrough() {
+    assert_eq!(expand("echo hello"), "echo hello");
+  }
+
+  #[test]
+  fn expand_no_false_node_in_middle() {
+    // "node:" appearing inside a string must not be expanded
+    assert_eq!(
+      expand("node -e \"require('node:fs')\""),
+      "node -e \"require('node:fs')\""
+    );
+  }
+
+  #[test]
+  fn expand_pnpm_does_not_trigger_npm() {
+    // "pnpm:" contains "npm:" as a substring — strip_prefix prevents false match
+    assert_eq!(expand("pnpm:test"), "pnpm run test");
+  }
+
+  // ── get_name() ────────────────────────────────────────────
+
+  #[test]
+  fn get_name_from_npm_prefix() {
+    assert_eq!(
+      get_name("npm:test", None, 0, None, 20, String::new()),
+      "test"
+    );
+  }
+
+  #[test]
+  fn get_name_from_yarn_prefix() {
+    assert_eq!(
+      get_name("yarn:lint", None, 1, None, 20, String::new()),
+      "lint"
+    );
+  }
+
+  #[test]
+  fn get_name_from_node_prefix() {
+    assert_eq!(
+      get_name("node:test", None, 0, None, 20, String::new()),
+      "test"
+    );
+  }
+
+  #[test]
+  fn get_name_from_deno_prefix() {
+    assert_eq!(
+      get_name("deno:serve", None, 0, None, 20, String::new()),
+      "serve"
+    );
+  }
+
+  #[test]
+  fn get_name_explicit_name_wins() {
+    assert_eq!(
+      get_name(
+        "npm:test",
+        Some("my-name".to_string()),
+        0,
+        None,
+        20,
+        String::new()
+      ),
+      "my-name"
+    );
+  }
+
+  #[test]
+  fn get_name_falls_back_to_index() {
+    assert_eq!(
+      get_name("echo hello", None, 3, None, 20, String::new()),
+      "3"
+    );
   }
 }


### PR DESCRIPTION
## Summary
Added the four missing command shortcuts (`yarn:`, `bun:`, `node:`, `deno:`) to match concurrently's feature set, and updated auto-naming to detect all six prefixes.

## Changes
- `src/command.rs` — Added `yarn_expander`, `bun_expander`, `node_expander`, and `deno_expander` functions; wired them into `expand()`; refactored `get_name()` to use a data-driven prefix list covering all six package managers (`pnpm:`, `yarn:`, `bun:`, `node:`, `deno:`, `npm:`)

## Issue
Closes #12

## Testing
- `cargo build` — compiles without errors
- `cargo test` — passes
- Manual verification:
- `mlti "yarn:test"` → expands to `yarn run test`
- `mlti "bun:dev"` → expands to `bun run dev`
- `mlti "node:test"` → expands to `node --run test`
- `mlti "deno:serve"` → expands to `deno task serve`
- Auto-naming extracts task name from all prefixes (e.g., `yarn:test` → name `test`)