### PR TITLE
Add `--pad-prefix` flag to align output columns (#14)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,10 @@ pub struct Commands {
   #[argh(option, short = 't', default = "default_timestamp_format()")]
   timestamp_format: String,
 
+  /// pad all prefixes to the same width to align output columns
+  #[argh(switch)]
+  pad_prefix: bool,
+
   /// success condition: all, first, last, command-{{index|name}}, !command-{{index|name}}
   #[argh(option, short = 's', default = "default_success()")]
   success: String,
@@ -120,6 +124,7 @@ pub struct MltiConfig {
   pub no_color: bool,
   pub group: bool,
   pub timestamp_format: String,
+  pub pad_prefix: bool,
   pub timings: bool,
 }
 
@@ -228,6 +233,7 @@ impl CommandParser {
         raw,
         no_color,
         timestamp_format,
+        pad_prefix: commands.pad_prefix,
         timings: commands.timings,
       },
     })
@@ -472,6 +478,7 @@ async fn main() -> Result<()> {
     scheduler_clone.run().await;
   });
 
+  let mut processes: Vec<Process> = Vec::with_capacity(arg_parser.len());
   for i in 0..arg_parser.len() {
     let r = rng.gen_range(75..255);
     let g = rng.gen_range(75..255);
@@ -487,7 +494,17 @@ async fn main() -> Result<()> {
       (r, g, b),
       mlti_config.timestamp_format.clone(),
     );
+    processes.push(my_cmd);
+  }
 
+  if mlti_config.pad_prefix {
+    let max_len = processes.iter().map(|p| p.name.len()).max().unwrap_or(0);
+    for p in processes.iter_mut() {
+      p.name = format!("{:<width$}", p.name, width = max_len);
+    }
+  }
+
+  for my_cmd in processes {
     task_queue
       .send_async(Task::new(
         my_cmd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,17 @@ impl SuccessCondition {
   }
 }
 
+fn pad_process_names(processes: &mut [Process]) {
+  let max_len = processes
+    .iter()
+    .map(|p| p.name.chars().count())
+    .max()
+    .unwrap_or(0);
+  for p in processes.iter_mut() {
+    p.name = format!("{:<width$}", p.name, width = max_len);
+  }
+}
+
 pub fn parse_names(names: Option<String>, seperator: String) -> Vec<String> {
   let names = match names {
     Some(names) => names.split(&seperator).map(|x| x.to_string()).collect(),
@@ -498,10 +509,7 @@ async fn main() -> Result<()> {
   }
 
   if mlti_config.pad_prefix {
-    let max_len = processes.iter().map(|p| p.name.len()).max().unwrap_or(0);
-    for p in processes.iter_mut() {
-      p.name = format!("{:<width$}", p.name, width = max_len);
-    }
+    pad_process_names(&mut processes);
   }
 
   for my_cmd in processes {
@@ -686,6 +694,78 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use command::Process;
+
+  // ---- pad_process_names ----
+
+  fn make_process(name: &str) -> Process {
+    Process::new(
+      "echo hello".to_string(),
+      Some(name.to_string()),
+      0,
+      None,
+      10,
+      (255, 255, 255),
+      "%Y-%m-%d %H:%M:%S".to_string(),
+    )
+  }
+
+  #[test]
+  fn pad_process_names_aligns_to_longest() {
+    let mut processes = vec![
+      make_process("api"),
+      make_process("frontend"),
+      make_process("db"),
+    ];
+    pad_process_names(&mut processes);
+    assert_eq!(processes[0].name, "api     ");
+    assert_eq!(processes[1].name, "frontend");
+    assert_eq!(processes[2].name, "db      ");
+    let widths: Vec<usize> = processes.iter().map(|p| p.name.chars().count()).collect();
+    assert!(widths.windows(2).all(|w| w[0] == w[1]));
+  }
+
+  #[test]
+  fn pad_process_names_single_process() {
+    let mut processes = vec![make_process("solo")];
+    pad_process_names(&mut processes);
+    assert_eq!(processes[0].name, "solo");
+  }
+
+  #[test]
+  fn pad_process_names_empty_list() {
+    let mut processes: Vec<Process> = vec![];
+    pad_process_names(&mut processes);
+    assert!(processes.is_empty());
+  }
+
+  #[test]
+  fn pad_process_names_equal_length() {
+    let mut processes = vec![
+      make_process("aaa"),
+      make_process("bbb"),
+      make_process("ccc"),
+    ];
+    pad_process_names(&mut processes);
+    assert_eq!(processes[0].name, "aaa");
+    assert_eq!(processes[1].name, "bbb");
+    assert_eq!(processes[2].name, "ccc");
+  }
+
+  #[test]
+  fn pad_process_names_unicode_chars() {
+    let mut processes = vec![
+      make_process("café"),
+      make_process("db"),
+    ];
+    pad_process_names(&mut processes);
+    assert_eq!(processes[0].name, "café");
+    assert_eq!(processes[1].name, "db  ");
+    assert_eq!(
+      processes[0].name.chars().count(),
+      processes[1].name.chars().count()
+    );
+  }
 
   // ---- SuccessCondition::parse ----
 


### PR DESCRIPTION
## Summary
Added `--pad-prefix` flag that pads all process name prefixes to the same width using right-padding (left-aligned names) with spaces.

## Changes
- `src/main.rs` — Added `--pad-prefix` switch to `Commands` struct and `pad_prefix` field to `MltiConfig`. Refactored the process creation loop to first collect all `Process` instances, then pad their names to the max length if `--pad-prefix` is set, then enqueue tasks.

## Issue
Closes #14

## Testing
- Review the PR diff for correctness
- Run the project's test suite