### PR TITLE
Support environment variable configuration (MLTI_* env vars) (#13)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,6 @@ pub struct CommandParser {
 /// Parse a boolean from an environment variable value.
 /// Treats "true" and "1" (case-insensitive) as true, everything else as false.
 /// Returns None if the variable is missing or empty.
-#[cfg_attr(not(test), allow(dead_code))]
 fn env_bool(key: &str) -> Option<bool> {
   std::env::var(key).ok().filter(|v| !v.is_empty()).map(|v| {
     let v = v.to_lowercase();
@@ -143,7 +142,6 @@ fn env_bool(key: &str) -> Option<bool> {
 
 /// Read an environment variable and parse it, returning None on missing or invalid values.
 /// Prints a warning to stderr if the value is present but cannot be parsed.
-#[cfg_attr(not(test), allow(dead_code))]
 fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
   match std::env::var(key) {
     Ok(v) if v.is_empty() => None,
@@ -981,5 +979,12 @@ mod tests {
     let cpus = num_cpus::get();
     let expected = (cpus as f32 * 0.5) as i32;
     assert_eq!(parse_max_processes(Some("50%".to_string())), expected);
+  }
+
+  // -- default functions --
+
+  #[test]
+  fn default_timestamp_format_matches_expected() {
+    assert_eq!(default_timestamp_format(), "%Y-%m-%d %H:%M:%S");
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ fn default_names_separator() -> String {
 fn default_success() -> String {
   "all".to_string()
 }
+fn default_timestamp_format() -> String {
+  String::from("%Y-%m-%d %H:%M:%S")
+}
 
 #[derive(FromArgs)]
 /// Launch some commands concurrently
@@ -92,7 +95,7 @@ pub struct Commands {
   version: bool,
 
   /// timestamp format for logging
-  #[argh(option, short = 't', default = "String::from(\"%Y-%m-%d %H:%M:%S\")")]
+  #[argh(option, short = 't', default = "default_timestamp_format()")]
   timestamp_format: String,
 
   /// success condition: all, first, last, command-{{index|name}}, !command-{{index|name}}
@@ -129,16 +132,31 @@ pub struct CommandParser {
 
 /// Parse a boolean from an environment variable value.
 /// Treats "true" and "1" (case-insensitive) as true, everything else as false.
+/// Returns None if the variable is missing or empty.
 fn env_bool(key: &str) -> Option<bool> {
-  std::env::var(key).ok().map(|v| {
-    let v = v.to_lowercase();
-    v == "true" || v == "1"
-  })
+  std::env::var(key)
+    .ok()
+    .filter(|v| !v.is_empty())
+    .map(|v| {
+      let v = v.to_lowercase();
+      v == "true" || v == "1"
+    })
 }
 
 /// Read an environment variable and parse it, returning None on missing or invalid values.
+/// Prints a warning to stderr if the value is present but cannot be parsed.
 fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
-  std::env::var(key).ok().and_then(|v| v.parse::<T>().ok())
+  match std::env::var(key) {
+    Ok(v) if v.is_empty() => None,
+    Ok(v) => match v.parse::<T>() {
+      Ok(parsed) => Some(parsed),
+      Err(_) => {
+        eprintln!("[mlti] warning: ignoring invalid value for {key}: {v:?}");
+        None
+      }
+    },
+    Err(_) => None,
+  }
 }
 
 impl CommandParser {
@@ -151,7 +169,9 @@ impl CommandParser {
     let kill_others_on_fail = commands.kill_others_on_fail
       || env_bool("MLTI_KILL_OTHERS_ON_FAIL").unwrap_or(false);
     let raw = commands.raw || env_bool("MLTI_RAW").unwrap_or(false);
-    let no_color = commands.no_color || env_bool("MLTI_NO_COLOR").unwrap_or(false);
+    let no_color = commands.no_color
+      || env_bool("MLTI_NO_COLOR").unwrap_or(false)
+      || std::env::var("NO_COLOR").map_or(false, |v| !v.is_empty());
     let group = commands.group || env_bool("MLTI_GROUP").unwrap_or(false);
 
     // For options with defaults: if CLI value equals the default, try the env var.
@@ -178,20 +198,24 @@ impl CommandParser {
       .prefix
       .or_else(|| std::env::var("MLTI_PREFIX").ok());
     let names = commands.names.or_else(|| std::env::var("MLTI_NAMES").ok());
+    let names_separator = if commands.names_seperator != default_names_separator() {
+      commands.names_seperator
+    } else {
+      std::env::var("MLTI_NAMES_SEPARATOR").unwrap_or(commands.names_seperator)
+    };
     let max_processes = commands
       .max_processes
       .or_else(|| std::env::var("MLTI_MAX_PROCESSES").ok());
 
     // For timestamp_format: if CLI value equals the default, try the env var.
-    let default_ts = String::from("%Y-%m-%d %H:%M:%S");
-    let timestamp_format = if commands.timestamp_format != default_ts {
+    let timestamp_format = if commands.timestamp_format != default_timestamp_format() {
       commands.timestamp_format
     } else {
       std::env::var("MLTI_TIMESTAMP_FORMAT").unwrap_or(commands.timestamp_format)
     };
 
     Ok(Self {
-      names: parse_names(names, commands.names_seperator),
+      names: parse_names(names, names_separator),
       processes: commands.processes,
       success_condition,
       mlti_config: MltiConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,25 +127,85 @@ pub struct CommandParser {
   success_condition: SuccessCondition,
 }
 
+/// Parse a boolean from an environment variable value.
+/// Treats "true" and "1" (case-insensitive) as true, everything else as false.
+fn env_bool(key: &str) -> Option<bool> {
+  std::env::var(key).ok().map(|v| {
+    let v = v.to_lowercase();
+    v == "true" || v == "1"
+  })
+}
+
+/// Read an environment variable and parse it, returning None on missing or invalid values.
+fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
+  std::env::var(key).ok().and_then(|v| v.parse::<T>().ok())
+}
+
 impl CommandParser {
   pub fn new(commands: Commands) -> Result<Self, String> {
     let success_condition = SuccessCondition::parse(&commands.success)?;
+
+    // For boolean switches: CLI true means explicitly set; otherwise fall back to env var.
+    let kill_others =
+      commands.kill_others || env_bool("MLTI_KILL_OTHERS").unwrap_or(false);
+    let kill_others_on_fail = commands.kill_others_on_fail
+      || env_bool("MLTI_KILL_OTHERS_ON_FAIL").unwrap_or(false);
+    let raw = commands.raw || env_bool("MLTI_RAW").unwrap_or(false);
+    let no_color = commands.no_color || env_bool("MLTI_NO_COLOR").unwrap_or(false);
+    let group = commands.group || env_bool("MLTI_GROUP").unwrap_or(false);
+
+    // For options with defaults: if CLI value equals the default, try the env var.
+    let restart_tries = if commands.restart_tries != default_restart_tries() {
+      commands.restart_tries
+    } else {
+      env_parse::<i64>("MLTI_RESTART_TRIES").unwrap_or(commands.restart_tries)
+    };
+
+    let restart_after = if commands.restart_after != default_restart_after() {
+      commands.restart_after
+    } else {
+      env_parse::<i64>("MLTI_RESTART_AFTER").unwrap_or(commands.restart_after)
+    };
+
+    let prefix_length = if commands.prefix_length != default_prefix_length() {
+      commands.prefix_length
+    } else {
+      env_parse::<i16>("MLTI_PREFIX_LENGTH").unwrap_or(commands.prefix_length)
+    };
+
+    // For Option<String> fields: CLI Some wins; otherwise try env var.
+    let prefix = commands
+      .prefix
+      .or_else(|| std::env::var("MLTI_PREFIX").ok());
+    let names = commands.names.or_else(|| std::env::var("MLTI_NAMES").ok());
+    let max_processes = commands
+      .max_processes
+      .or_else(|| std::env::var("MLTI_MAX_PROCESSES").ok());
+
+    // For timestamp_format: if CLI value equals the default, try the env var.
+    let default_ts = String::from("%Y-%m-%d %H:%M:%S");
+    let timestamp_format = if commands.timestamp_format != default_ts {
+      commands.timestamp_format
+    } else {
+      std::env::var("MLTI_TIMESTAMP_FORMAT").unwrap_or(commands.timestamp_format)
+    };
+
     Ok(Self {
-      names: parse_names(commands.names, commands.names_seperator),
+      names: parse_names(names, commands.names_seperator),
       processes: commands.processes,
       success_condition,
       mlti_config: MltiConfig {
-        group: commands.group,
-        kill_others: commands.kill_others,
-        kill_others_on_fail: commands.kill_others_on_fail,
-        restart_tries: commands.restart_tries,
-        restart_after: commands.restart_after,
-        prefix: commands.prefix,
-        prefix_length: commands.prefix_length,
-        max_processes: parse_max_processes(commands.max_processes),
-        raw: commands.raw,
-        no_color: commands.no_color,
-        timestamp_format: commands.timestamp_format,
+        group,
+        kill_others,
+        kill_others_on_fail,
+        restart_tries,
+        restart_after,
+        prefix,
+        prefix_length,
+        max_processes: parse_max_processes(max_processes),
+        raw,
+        no_color,
+        timestamp_format,
         timings: commands.timings,
       },
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ pub struct CommandParser {
 /// Parse a boolean from an environment variable value.
 /// Treats "true" and "1" (case-insensitive) as true, everything else as false.
 /// Returns None if the variable is missing or empty.
+#[cfg_attr(not(test), allow(dead_code))]
 fn env_bool(key: &str) -> Option<bool> {
   std::env::var(key).ok().filter(|v| !v.is_empty()).map(|v| {
     let v = v.to_lowercase();
@@ -142,6 +143,7 @@ fn env_bool(key: &str) -> Option<bool> {
 
 /// Read an environment variable and parse it, returning None on missing or invalid values.
 /// Prints a warning to stderr if the value is present but cannot be parsed.
+#[cfg_attr(not(test), allow(dead_code))]
 fn env_parse<T: std::str::FromStr>(key: &str) -> Option<T> {
   match std::env::var(key) {
     Ok(v) if v.is_empty() => None,
@@ -838,5 +840,146 @@ mod tests {
         .evaluate(&exit_codes, &names),
       1
     );
+  }
+
+  // ── env_bool ────────────────────────────────────────────────────────────────
+
+  fn with_env_var<F: FnOnce()>(key: &str, value: &str, f: F) {
+    std::env::set_var(key, value);
+    f();
+    std::env::remove_var(key);
+  }
+
+  fn without_env_var<F: FnOnce()>(key: &str, f: F) {
+    std::env::remove_var(key);
+    f();
+  }
+
+  #[test]
+  fn env_bool_true_values() {
+    with_env_var("MLTI_TEST_BOOL_TRUE_LOWER", "true", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_TRUE_LOWER"), Some(true));
+    });
+    with_env_var("MLTI_TEST_BOOL_TRUE_UPPER", "TRUE", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_TRUE_UPPER"), Some(true));
+    });
+    with_env_var("MLTI_TEST_BOOL_TRUE_MIXED", "True", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_TRUE_MIXED"), Some(true));
+    });
+    with_env_var("MLTI_TEST_BOOL_ONE", "1", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_ONE"), Some(true));
+    });
+  }
+
+  #[test]
+  fn env_bool_false_values() {
+    with_env_var("MLTI_TEST_BOOL_FALSE_LOWER", "false", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_FALSE_LOWER"), Some(false));
+    });
+    with_env_var("MLTI_TEST_BOOL_FALSE_UPPER", "FALSE", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_FALSE_UPPER"), Some(false));
+    });
+    with_env_var("MLTI_TEST_BOOL_ZERO", "0", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_ZERO"), Some(false));
+    });
+    with_env_var("MLTI_TEST_BOOL_NO", "no", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_NO"), Some(false));
+    });
+    with_env_var("MLTI_TEST_BOOL_ANYTHING", "anything", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_ANYTHING"), Some(false));
+    });
+  }
+
+  #[test]
+  fn env_bool_empty_returns_none() {
+    with_env_var("MLTI_TEST_BOOL_EMPTY", "", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_EMPTY"), None);
+    });
+  }
+
+  #[test]
+  fn env_bool_missing_returns_none() {
+    without_env_var("MLTI_TEST_BOOL_MISSING_XYZ", || {
+      assert_eq!(env_bool("MLTI_TEST_BOOL_MISSING_XYZ"), None);
+    });
+  }
+
+  // ── env_parse ────────────────────────────────────────────────────────────────
+
+  #[test]
+  fn env_parse_valid_i64() {
+    with_env_var("MLTI_TEST_PARSE_42", "42", || {
+      assert_eq!(env_parse::<i64>("MLTI_TEST_PARSE_42"), Some(42));
+    });
+  }
+
+  #[test]
+  fn env_parse_negative_i64() {
+    with_env_var("MLTI_TEST_PARSE_NEG5", "-5", || {
+      assert_eq!(env_parse::<i64>("MLTI_TEST_PARSE_NEG5"), Some(-5));
+    });
+  }
+
+  #[test]
+  fn env_parse_invalid_returns_none() {
+    with_env_var("MLTI_TEST_PARSE_INVALID", "notanumber", || {
+      assert_eq!(env_parse::<i64>("MLTI_TEST_PARSE_INVALID"), None);
+    });
+  }
+
+  #[test]
+  fn env_parse_empty_returns_none() {
+    with_env_var("MLTI_TEST_PARSE_EMPTY", "", || {
+      assert_eq!(env_parse::<i64>("MLTI_TEST_PARSE_EMPTY"), None);
+    });
+  }
+
+  #[test]
+  fn env_parse_missing_returns_none() {
+    without_env_var("MLTI_TEST_PARSE_MISSING_XYZ", || {
+      assert_eq!(env_parse::<i64>("MLTI_TEST_PARSE_MISSING_XYZ"), None);
+    });
+  }
+
+  // ── parse_names ──────────────────────────────────────────────────────────────
+
+  #[test]
+  fn parse_names_comma_separated() {
+    assert_eq!(
+      parse_names(Some("foo,bar,baz".to_string()), ",".to_string()),
+      vec!["foo", "bar", "baz"]
+    );
+  }
+
+  #[test]
+  fn parse_names_custom_separator() {
+    assert_eq!(
+      parse_names(Some("foo|bar".to_string()), "|".to_string()),
+      vec!["foo", "bar"]
+    );
+  }
+
+  #[test]
+  fn parse_names_none_returns_empty() {
+    assert_eq!(parse_names(None, ",".to_string()), Vec::<String>::new());
+  }
+
+  // ── parse_max_processes ──────────────────────────────────────────────────────
+
+  #[test]
+  fn parse_max_processes_none_returns_i32_max() {
+    assert_eq!(parse_max_processes(None), i32::MAX);
+  }
+
+  #[test]
+  fn parse_max_processes_numeric() {
+    assert_eq!(parse_max_processes(Some("4".to_string())), 4);
+  }
+
+  #[test]
+  fn parse_max_processes_percentage() {
+    let cpus = num_cpus::get();
+    let expected = (cpus as f32 * 0.5) as i32;
+    assert_eq!(parse_max_processes(Some("50%".to_string())), expected);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,13 +134,10 @@ pub struct CommandParser {
 /// Treats "true" and "1" (case-insensitive) as true, everything else as false.
 /// Returns None if the variable is missing or empty.
 fn env_bool(key: &str) -> Option<bool> {
-  std::env::var(key)
-    .ok()
-    .filter(|v| !v.is_empty())
-    .map(|v| {
-      let v = v.to_lowercase();
-      v == "true" || v == "1"
-    })
+  std::env::var(key).ok().filter(|v| !v.is_empty()).map(|v| {
+    let v = v.to_lowercase();
+    v == "true" || v == "1"
+  })
 }
 
 /// Read an environment variable and parse it, returning None on missing or invalid values.
@@ -171,7 +168,7 @@ impl CommandParser {
     let raw = commands.raw || env_bool("MLTI_RAW").unwrap_or(false);
     let no_color = commands.no_color
       || env_bool("MLTI_NO_COLOR").unwrap_or(false)
-      || std::env::var("NO_COLOR").map_or(false, |v| !v.is_empty());
+      || std::env::var("NO_COLOR").is_ok_and(|v| !v.is_empty());
     let group = commands.group || env_bool("MLTI_GROUP").unwrap_or(false);
 
     // For options with defaults: if CLI value equals the default, try the env var.
@@ -208,7 +205,8 @@ impl CommandParser {
       .or_else(|| std::env::var("MLTI_MAX_PROCESSES").ok());
 
     // For timestamp_format: if CLI value equals the default, try the env var.
-    let timestamp_format = if commands.timestamp_format != default_timestamp_format() {
+    let timestamp_format = if commands.timestamp_format != default_timestamp_format()
+    {
       commands.timestamp_format
     } else {
       std::env::var("MLTI_TIMESTAMP_FORMAT").unwrap_or(commands.timestamp_format)


### PR DESCRIPTION
## Summary
Added `MLTI_*` environment variable support to `CommandParser::new()`. Two helper functions (`env_bool` and `env_parse`) read and parse env vars. CLI arguments always take precedence: - **Boolean switches** (`-k`, `-r`, `--no-color`, `-g`, `--kill-others-on-fail`): OR'd with env var — CLI `true` always wins, env var fills in when CLI is at default `false` - **Numeric options** (`--restart-tries`, `--restart-after`, `-l`): env var used only when CLI value equals the default

## Changes
- `src/main.rs` — Added `env_bool()` and `env_parse()` helper functions; rewrote `CommandParser::new()` to merge env vars with CLI args

## Issue
Closes #13

## Testing
- **Kill others via env var**: `MLTI_KILL_OTHERS=true cargo run -- "echo hi" "echo bye"` — should show "Kill others flag present"
- **Raw mode via env var**: `MLTI_RAW=1 cargo run -- "echo hi" "echo bye"` — output has no prefixes/colors
- **CLI overrides env**: `MLTI_RAW=true cargo run -- -r "echo hi"` — same as without env var (CLI wins)
- **Invalid values ignored**: `MLTI_RESTART_TRIES=notanumber cargo run -- "echo hi"` — uses default (0)
- **String env vars**: `MLTI_NAMES=foo,bar cargo run -- "echo hi" "echo bye"` — processes named "foo" and "bar"