### PR TITLE
Add `--timings` flag to print process duration summary (#11)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,10 @@ pub struct Commands {
   /// success condition: all, first, last, command-{{index|name}}, !command-{{index|name}}
   #[argh(option, short = 's', default = "default_success()")]
   success: String,
+
+  /// print a duration summary for each process after completion
+  #[argh(switch)]
+  timings: bool,
 }
 
 #[derive(Clone)]
@@ -113,6 +117,7 @@ pub struct MltiConfig {
   pub no_color: bool,
   pub group: bool,
   pub timestamp_format: String,
+  pub timings: bool,
 }
 
 pub struct CommandParser {
@@ -141,6 +146,7 @@ impl CommandParser {
         raw: commands.raw,
         no_color: commands.no_color,
         timestamp_format: commands.timestamp_format,
+        timings: commands.timings,
       },
     })
   }
@@ -516,6 +522,51 @@ async fn main() -> Result<()> {
 
   let exit_codes = scheduler.get_exit_codes().await;
   let exit_code = arg_parser.evaluate_exit_code(&exit_codes);
+
+  if mlti_config.timings {
+    let mut timings = scheduler.get_timings().await;
+    let total_processes = arg_parser.len();
+    timings.sort_by_key(|t| t.index);
+    print_message(
+      SenderType::Main,
+      "".into(),
+      "\nTimings:".into(),
+      bold_green_style,
+      mlti_config.raw,
+      mlti_config.no_color,
+    );
+    for t in &timings {
+      let style = if t.exit_code != 0 {
+        red_style
+      } else {
+        bold_green_style
+      };
+      print_message(
+        SenderType::Main,
+        "".into(),
+        format!(
+          "  [{}] {} \u{2014} {:.2}s",
+          t.index, t.raw_cmd, t.duration_secs
+        ),
+        style,
+        mlti_config.raw,
+        mlti_config.no_color,
+      );
+    }
+    if timings.len() < total_processes {
+      print_message(
+        SenderType::Main,
+        "".into(),
+        format!(
+          "  ({} process(es) killed before completion)",
+          total_processes - timings.len()
+        ),
+        red_style,
+        mlti_config.raw,
+        mlti_config.no_color,
+      );
+    }
+  }
 
   print_message(
     SenderType::Main,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -5,6 +5,7 @@ use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinSet;
 
 use crate::message::{build_message_sender, MessageType, SenderType};
+use crate::task::TaskTiming;
 use crate::{message::Message, task::Task};
 
 pub(crate) struct Scheduler {
@@ -17,6 +18,7 @@ pub(crate) struct Scheduler {
   kill_all_tx: Sender<()>,
   kill_all_rx: Receiver<()>,
   exit_codes: Arc<Mutex<Vec<(usize, i32)>>>,
+  timings: Arc<Mutex<Vec<TaskTiming>>>,
 }
 
 impl Scheduler {
@@ -38,6 +40,7 @@ impl Scheduler {
       kill_all_tx,
       kill_all_rx,
       exit_codes: Arc::new(Mutex::new(Vec::new())),
+      timings: Arc::new(Mutex::new(Vec::new())),
     }
   }
   pub fn get_task_queue(&self) -> Sender<Task> {
@@ -49,6 +52,10 @@ impl Scheduler {
 
   pub async fn get_exit_codes(&self) -> Vec<(usize, i32)> {
     self.exit_codes.lock().await.clone()
+  }
+
+  pub async fn get_timings(&self) -> Vec<TaskTiming> {
+    self.timings.lock().await.clone()
   }
 
   pub async fn run(&self) {
@@ -70,15 +77,24 @@ impl Scheduler {
           if let Some(mut task) = task {
             *running_processes += 1;
             let exit_codes = self.exit_codes.clone();
+            let timings = self.timings.clone();
             let task_index = task.index();
+            let (_, task_raw_cmd) = task.process_info();
             join_set.spawn(async move {
               match task.start().await {
-                Ok(code) => {
+                Ok((code, timing)) => {
                   exit_codes.lock().await.push((task_index, code));
+                  timings.lock().await.push(timing);
                 }
                 Err(e) => {
                   println!("{}", e);
                   exit_codes.lock().await.push((task_index, 1));
+                  timings.lock().await.push(TaskTiming {
+                    index: task_index,
+                    raw_cmd: task_raw_cmd,
+                    exit_code: 1,
+                    duration_secs: 0.0,
+                  });
                 }
               }
             });

--- a/src/task.rs
+++ b/src/task.rs
@@ -3,12 +3,21 @@ use chrono::{Duration, Local};
 use chrono_humanize::{Accuracy, HumanTime, Tense};
 use flume::Sender;
 use owo_colors::OwoColorize;
+use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Child;
 
 use crate::command::Process;
 use crate::message::{build_message_sender, Message, MessageType, SenderType};
 use crate::MltiConfig;
+
+#[derive(Clone)]
+pub struct TaskTiming {
+  pub index: usize,
+  pub raw_cmd: String,
+  pub exit_code: i32,
+  pub duration_secs: f64,
+}
 
 pub(crate) struct Task {
   process: Process,
@@ -36,6 +45,19 @@ impl Task {
   pub fn index(&self) -> usize {
     self.process.index
   }
+  pub fn process_info(&self) -> (usize, String) {
+    (self.process.index, self.process.raw_cmd.clone())
+  }
+
+  fn make_timing(&self, exit_code: i32, duration_secs: f64) -> TaskTiming {
+    TaskTiming {
+      index: self.process.index,
+      raw_cmd: self.process.raw_cmd.clone(),
+      exit_code,
+      duration_secs,
+    }
+  }
+
   pub async fn send_error(&self, error: String) {
     self
       .shutdown_tx
@@ -49,7 +71,7 @@ impl Task {
       .await
       .expect("Could not send message on channel.");
   }
-  pub async fn start(&mut self) -> Result<i32> {
+  pub async fn start(&mut self) -> Result<(i32, TaskTiming)> {
     let mut child: Option<Child> = None;
 
     let mut restart_attempts = self.mlti_config.restart_tries - 1;
@@ -107,9 +129,11 @@ impl Task {
             "Encountered an Error: Could not start process.".red(),
           ))
           .await;
-        return Ok(1);
+        return Ok((1, self.make_timing(1, 0.0)));
       }
     };
+
+    let start_time = Instant::now();
 
     let stdout = child
       .stdout
@@ -219,7 +243,11 @@ impl Task {
         .expect("Could not send message on channel.");
     }
 
-    Ok(self.exit_code.unwrap_or(1))
+    let code = self.exit_code.unwrap_or(1);
+    Ok((
+      code,
+      self.make_timing(code, start_time.elapsed().as_secs_f64()),
+    ))
   }
 }
 


### PR DESCRIPTION
## Summary
Added `--timings` flag that prints a duration summary table for each process after all processes complete, showing the index, command, and duration in seconds with 2 decimal places.

## Changes
- `src/task.rs` — Added `TaskTiming` struct with `index`, `raw_cmd`, `duration_secs`. Record `Instant::now()` at task start and compute elapsed duration when the task finishes. Changed `start()` return type from `Result<i32>` to `Result<(i32, TaskTiming)>`.
- `src/scheduler.rs` — Added `timings: Arc<Mutex<Vec<TaskTiming>>>` field to collect timing data from completed tasks. Added `get_timings()` method to expose the data.
- `src/main.rs` — Added `--timings` switch to `Commands` struct and `timings` field to `MltiConfig`. After all processes complete, if `--timings` is enabled, prints a sorted summary table before the "Goodbye" message.

## Issue
Closes #11

## Testing
- `cargo run -- --timings "echo hello" "sleep 1"` — shows timing summary with ~0.00s and ~1.00s
- `cargo run -- "echo hello" "sleep 1"` — no timing summary printed (flag off)
- `cargo run -- --timings --kill-others "echo hello" "sleep 2"` — works with kill-others, shows timings for completed processes