### PR TITLE
Add `--hide` flag to suppress output from specific processes (#15)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,26 @@ pub struct MltiConfig {
   pub timestamp_format: String,
   pub pad_prefix: bool,
   pub timings: bool,
-  pub hide_list: Vec<String>,
+  pub hide_list: Vec<HideTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HideTarget {
+  Index(usize),
+  Name(String),
+}
+
+impl HideTarget {
+  pub fn matches(&self, index: Option<usize>, name: &str) -> bool {
+    match self {
+      HideTarget::Index(i) => index == Some(*i),
+      HideTarget::Name(n) => n == name,
+    }
+  }
+}
+
+pub fn is_hidden_by(list: &[HideTarget], index: Option<usize>, name: &str) -> bool {
+  list.iter().any(|t| t.matches(index, name))
 }
 
 pub struct CommandParser {
@@ -364,12 +383,16 @@ pub fn parse_names(names: Option<String>, seperator: String) -> Vec<String> {
   names
 }
 
-pub fn parse_hide_list(hide: Option<String>) -> Vec<String> {
+pub fn parse_hide_list(hide: Option<String>) -> Vec<HideTarget> {
   match hide {
     Some(h) => h
       .split(',')
-      .map(|s| s.trim().to_string())
+      .map(|s| s.trim())
       .filter(|s| !s.is_empty())
+      .map(|s| match s.parse::<usize>() {
+        Ok(i) => HideTarget::Index(i),
+        Err(_) => HideTarget::Name(s.to_string()),
+      })
       .collect(),
     None => vec![],
   }
@@ -426,14 +449,7 @@ async fn main() -> Result<()> {
       .listen(
         |message: Message, raw: bool, no_color: bool| match message.type_ {
           MessageType::Error | MessageType::Text => {
-            let hidden = if let Some(idx) = message.sender.index {
-              hide_list
-                .iter()
-                .any(|h| h == &idx.to_string() || h == &message.name)
-            } else {
-              false
-            };
-            if !hidden {
+            if !is_hidden_by(&hide_list, message.sender.index, &message.name) {
               print_message(
                 message.sender.type_,
                 message.name,
@@ -1099,5 +1115,99 @@ mod tests {
   #[test]
   fn default_timestamp_format_matches_expected() {
     assert_eq!(default_timestamp_format(), "%Y-%m-%d %H:%M:%S");
+  }
+
+  // ---- parse_hide_list / HideTarget / is_hidden_by ----
+
+  #[test]
+  fn parse_hide_list_none_is_empty() {
+    assert_eq!(parse_hide_list(None), Vec::<HideTarget>::new());
+  }
+
+  #[test]
+  fn parse_hide_list_empty_string_is_empty() {
+    assert_eq!(parse_hide_list(Some("".into())), Vec::<HideTarget>::new());
+  }
+
+  #[test]
+  fn parse_hide_list_whitespace_and_commas_is_empty() {
+    assert_eq!(
+      parse_hide_list(Some("  ,  ,".into())),
+      Vec::<HideTarget>::new()
+    );
+  }
+
+  #[test]
+  fn parse_hide_list_single_index() {
+    assert_eq!(
+      parse_hide_list(Some("0".into())),
+      vec![HideTarget::Index(0)]
+    );
+  }
+
+  #[test]
+  fn parse_hide_list_single_name() {
+    assert_eq!(
+      parse_hide_list(Some("foo".into())),
+      vec![HideTarget::Name("foo".into())]
+    );
+  }
+
+  #[test]
+  fn parse_hide_list_mixed_indices_and_names() {
+    assert_eq!(
+      parse_hide_list(Some("0,foo,2".into())),
+      vec![
+        HideTarget::Index(0),
+        HideTarget::Name("foo".into()),
+        HideTarget::Index(2),
+      ]
+    );
+  }
+
+  #[test]
+  fn parse_hide_list_trims_whitespace() {
+    assert_eq!(
+      parse_hide_list(Some(" 0 , foo ".into())),
+      vec![HideTarget::Index(0), HideTarget::Name("foo".into())]
+    );
+  }
+
+  #[test]
+  fn parse_hide_list_trailing_comma_ignored() {
+    assert_eq!(
+      parse_hide_list(Some("0,foo,".into())),
+      vec![HideTarget::Index(0), HideTarget::Name("foo".into())]
+    );
+  }
+
+  #[test]
+  fn hide_target_index_matches_only_by_index() {
+    let t = HideTarget::Index(1);
+    assert!(t.matches(Some(1), "anything"));
+    assert!(!t.matches(Some(0), "anything"));
+    assert!(!t.matches(None, "anything"));
+  }
+
+  #[test]
+  fn hide_target_name_matches_only_by_name() {
+    let t = HideTarget::Name("build".into());
+    assert!(t.matches(Some(5), "build"));
+    assert!(t.matches(None, "build"));
+    assert!(!t.matches(Some(5), "serve"));
+  }
+
+  #[test]
+  fn is_hidden_by_empty_list_hides_nothing() {
+    assert!(!is_hidden_by(&[], Some(0), "foo"));
+  }
+
+  #[test]
+  fn is_hidden_by_matches_any_entry() {
+    let list = vec![HideTarget::Index(0), HideTarget::Name("foo".into())];
+    assert!(is_hidden_by(&list, Some(0), "bar"));
+    assert!(is_hidden_by(&list, Some(2), "foo"));
+    assert!(!is_hidden_by(&list, Some(2), "bar"));
+    assert!(!is_hidden_by(&list, None, "bar"));
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,10 @@ pub struct Commands {
   #[argh(switch, short = 'g')]
   group: bool,
 
+  /// comma-separated list of process indices or names to hide output from
+  #[argh(option)]
+  hide: Option<String>,
+
   /// processes to run
   #[argh(positional)]
   processes: Vec<String>,
@@ -126,6 +130,7 @@ pub struct MltiConfig {
   pub timestamp_format: String,
   pub pad_prefix: bool,
   pub timings: bool,
+  pub hide_list: Vec<String>,
 }
 
 pub struct CommandParser {
@@ -235,6 +240,7 @@ impl CommandParser {
         timestamp_format,
         pad_prefix: commands.pad_prefix,
         timings: commands.timings,
+        hide_list: parse_hide_list(commands.hide),
       },
     })
   }
@@ -358,6 +364,17 @@ pub fn parse_names(names: Option<String>, seperator: String) -> Vec<String> {
   names
 }
 
+pub fn parse_hide_list(hide: Option<String>) -> Vec<String> {
+  match hide {
+    Some(h) => h
+      .split(',')
+      .map(|s| s.trim().to_string())
+      .filter(|s| !s.is_empty())
+      .collect(),
+    None => vec![],
+  }
+}
+
 pub fn parse_max_processes(max_processes: Option<String>) -> i32 {
   match max_processes {
     Some(max) => {
@@ -391,6 +408,7 @@ async fn main() -> Result<()> {
     mlti_config.no_color,
     arg_parser.len(),
     false,
+    vec![],
   );
   let shutdown_tx = shutdown_messenger.get_sender();
   let mut messenger = messenger::Messenger::new(
@@ -398,33 +416,33 @@ async fn main() -> Result<()> {
     mlti_config.no_color,
     arg_parser.len(),
     mlti_config.group,
+    mlti_config.hide_list.clone(),
   );
   let message_tx = messenger.get_sender();
 
+  let hide_list = mlti_config.hide_list.clone();
   let messenger_handle = tokio::spawn(async move {
     messenger
       .listen(
         |message: Message, raw: bool, no_color: bool| match message.type_ {
-          MessageType::Error => {
-            print_message(
-              message.sender.type_,
-              message.name,
-              message.data,
-              message.style,
-              raw,
-              no_color,
-            );
-            0
-          }
-          MessageType::Text => {
-            print_message(
-              message.sender.type_,
-              message.name,
-              message.data,
-              message.style,
-              raw,
-              no_color,
-            );
+          MessageType::Error | MessageType::Text => {
+            let hidden = if let Some(idx) = message.sender.index {
+              hide_list
+                .iter()
+                .any(|h| h == &idx.to_string() || h == &message.name)
+            } else {
+              false
+            };
+            if !hidden {
+              print_message(
+                message.sender.type_,
+                message.name,
+                message.data,
+                message.style,
+                raw,
+                no_color,
+              );
+            }
             0
           }
           MessageType::Kill => 1,

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -3,6 +3,7 @@ use owo_colors::{OwoColorize, Style};
 use std::collections::VecDeque;
 
 use crate::message::{Message, MessageType, SenderType};
+use crate::{is_hidden_by, HideTarget};
 
 pub struct Messenger {
   sender: Sender<Message>,
@@ -11,7 +12,7 @@ pub struct Messenger {
   no_color: bool,
   group: bool,
   message_queue: Vec<VecDeque<Message>>,
-  hide_list: Vec<String>,
+  hide_list: Vec<HideTarget>,
 }
 
 impl Messenger {
@@ -20,7 +21,7 @@ impl Messenger {
     no_color: bool,
     num_commands: usize,
     group: bool,
-    hide_list: Vec<String>,
+    hide_list: Vec<HideTarget>,
   ) -> Self {
     let (sender, receiver) = flume::unbounded::<Message>();
 
@@ -79,13 +80,7 @@ impl Messenger {
   pub fn flush(&mut self) {
     for queue in self.message_queue.iter_mut() {
       while let Some(message) = queue.pop_front() {
-        if self.hide_list.iter().any(|h| {
-          message
-            .sender
-            .index
-            .is_some_and(|idx| h == &idx.to_string())
-            || h == &message.name
-        }) {
+        if is_hidden_by(&self.hide_list, message.sender.index, &message.name) {
           continue;
         }
         print_message(

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -11,10 +11,17 @@ pub struct Messenger {
   no_color: bool,
   group: bool,
   message_queue: Vec<VecDeque<Message>>,
+  hide_list: Vec<String>,
 }
 
 impl Messenger {
-  pub fn new(raw: bool, no_color: bool, num_commands: usize, group: bool) -> Self {
+  pub fn new(
+    raw: bool,
+    no_color: bool,
+    num_commands: usize,
+    group: bool,
+    hide_list: Vec<String>,
+  ) -> Self {
     let (sender, receiver) = flume::unbounded::<Message>();
 
     let message_queues = (0..num_commands)
@@ -28,6 +35,7 @@ impl Messenger {
       no_color,
       group,
       message_queue: message_queues,
+      hide_list,
     }
   }
   pub fn get_sender(&self) -> Sender<Message> {
@@ -71,6 +79,15 @@ impl Messenger {
   pub fn flush(&mut self) {
     for queue in self.message_queue.iter_mut() {
       while let Some(message) = queue.pop_front() {
+        if self.hide_list.iter().any(|h| {
+          message
+            .sender
+            .index
+            .is_some_and(|idx| h == &idx.to_string())
+            || h == &message.name
+        }) {
+          continue;
+        }
         print_message(
           message.sender.type_,
           message.name,


### PR DESCRIPTION
## Summary
Added `--hide` flag to suppress output from specific processes. The flag accepts a comma-separated list of process indices or names. Hidden processes still execute and their exit codes are tracked.

## Changes
- `src/main.rs` — Added `--hide` CLI option to `Commands` struct, `hide_list: Vec<String>` to `MltiConfig`, `parse_hide_list()` function, and filtering logic in the messenger callback closure
- `src/messenger.rs` — Added `hide_list` field to `Messenger` struct, updated `new()` constructor to accept it, and added filtering in `flush()` for grouped output mode

## Issue
Closes #15

## Testing
- `cargo run -- --hide 0 "echo hidden" "echo visible"` — Only shows output from process 1
- `cargo run -- --hide foo -n "foo,bar" "echo hidden" "echo visible"` — Hides output from named process "foo"
- `cargo run -- --hide 0,2 "echo zero" "echo one" "echo two"` — Hides output from processes 0 and 2
- `cargo run -- --hide 0 "exit 1" "echo visible"` — Hidden process exit code (1) is still tracked (program exits with code 1)