### PR TITLE
Fix rustfmt for pad-prefix tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -721,7 +721,8 @@ mod tests {
     assert_eq!(processes[0].name, "api     ");
     assert_eq!(processes[1].name, "frontend");
     assert_eq!(processes[2].name, "db      ");
-    let widths: Vec<usize> = processes.iter().map(|p| p.name.chars().count()).collect();
+    let widths: Vec<usize> =
+      processes.iter().map(|p| p.name.chars().count()).collect();
     assert!(widths.windows(2).all(|w| w[0] == w[1]));
   }
 
@@ -754,10 +755,7 @@ mod tests {
 
   #[test]
   fn pad_process_names_unicode_chars() {
-    let mut processes = vec![
-      make_process("café"),
-      make_process("db"),
-    ];
+    let mut processes = vec![make_process("café"), make_process("db")];
     pad_process_names(&mut processes);
     assert_eq!(processes[0].name, "café");
     assert_eq!(processes[1].name, "db  ");


### PR DESCRIPTION
## Summary
- Wrap long line in `pad_process_names_aligns_to_longest` test to satisfy rustfmt
- Collapse short 2-element vec into single line in `pad_process_names_unicode_chars` test

Fixes CI rustfmt failure from #17 merge.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>